### PR TITLE
Make device specific dependencies 'extras'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,14 +30,16 @@ install_requires =
   labscript_utils>=2.13.2
   numpy>=1.15.1
   pillow
-  PyDAQmx
-  PyNIVision
   pyserial
   qtutils>=2.2.3
-  spinapi
   zprocess>=2.18.0
 setup_requires =
   setuptools_scm
+
+[options.extras_require]
+spincore = spinapi
+nidaqmx = PyDAQmx
+nivision = PyNIVision
 
 [dist_conda]
 pythons = 3.6, 3.7, 3.8


### PR DESCRIPTION
Rather than include dependencies specific to particular labscript device driver(s) in `install_requires`, use [setuptools 'extras'](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) instead.

This will allow users to choose which additional dependencies to include when installing labscript-devices. Specifically, this PR sees the following moved from `install_requires` to `extras_require`:

```ini
[options.extras_require]
spincore = spinapi
nidaqmx = PyDAQmx
nivision = PyNIVision
```
If a user wants to control a National Instruments DAQ product and an IMAQdx camera they would install labscipt-devices using: 
```
$ pip install labscript-devices[nidaqmx,nivision]
```

The keys for doing so could be based on device manufacturer, product line, SDK, or existing sub-module names, e.g. `NI_DAQmx` and `IMAQdxCamera` instead of the above choices.

This would allow bindings like `labscript_devices.AndorSolis.andor_sdk` and `labscript_devices.atsapi` to be independent packages.

Are there any currently undeclared dependencies?