### PR TITLE
Obtain own version without external functions

### DIFF
--- a/labscript_devices/__init__.py
+++ b/labscript_devices/__init__.py
@@ -21,11 +21,7 @@ import inspect
 from labscript_utils import labscript_suite_install_dir, dedent
 from labscript_utils.labconfig import LabConfig
 
-from labscript_utils.versions import get_version, NoVersionInfo
-from pathlib import Path
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__
 
 check_version('qtutils', '2.0.0', '3.0.0')
 check_version('labscript', '2.6', '3')

--- a/labscript_devices/__version__.py
+++ b/labscript_devices/__version__.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   blacs>=2.7.0
+  importlib_metadata ; python_version<'3.8'
   labscript>=2.6.0
   labscript_utils>=2.13.2
   numpy>=1.15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   blacs>=2.7.0
-  importlib_metadata ; python_version<'3.8'
+  importlib_metadata
   labscript>=2.6.0
   labscript_utils>=2.13.2
   numpy>=1.15.1


### PR DESCRIPTION
Per labscript-suite/runmanager#81, with the addition of making the importlib_metadata requirement python<'3.8'.