### PR TITLE
Remove cruft

### DIFF
--- a/labscript_devices/AlazarTechBoard.py
+++ b/labscript_devices/AlazarTechBoard.py
@@ -2,17 +2,12 @@
 # Hacked up from NIboard.py by LDT 2017-01-26
 #
 # Copyright (c) Monash University 2017
-from __future__ import division, unicode_literals, print_function
 import ctypes
 import numpy as np
 import signal
 import sys
 import time
 from tqdm import tqdm
-
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 # Install atsapi.py into site-packages for this to work
 # or keep in local directory.
@@ -275,11 +270,7 @@ class GuilessWorker(Worker):
         global h5py
         import labscript_utils.h5_lock
         import h5py
-        from labscript_utils import PY2
-        if PY2:
-            from Queue import Queue
-        else:
-            from queue import Queue
+        from queue import Queue
         import threading
 
         # SDK startup

--- a/labscript_devices/AndorSolis/andor_sdk/andor_solis.py
+++ b/labscript_devices/AndorSolis/andor_sdk/andor_solis.py
@@ -12,8 +12,6 @@ import numpy as np
 from .status_codes import _SC
 from .andor_structures import ColorDemosaicInfo, AndorCapabilities
 
-PYTHON = sys.version_info
-
 # Custom ctypes
 at_32 = ctypes.c_long
 at_64 = ctypes.c_uint64

--- a/labscript_devices/Camera.py
+++ b/labscript_devices/Camera.py
@@ -10,15 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-
-from labscript_utils import check_version
-check_version('labscript', '2.0.1', '3')
-check_version('zprocess', '2.4.8', '3')
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import BLACS_tab
 from labscript import TriggerableDevice, LabscriptError, set_passed_properties
 import numpy as np

--- a/labscript_devices/CiceroOpalKellyXEM3001.py
+++ b/labscript_devices/CiceroOpalKellyXEM3001.py
@@ -11,11 +11,6 @@
 #                                                                   #
 #####################################################################
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript import Device, PseudoclockDevice, Pseudoclock, ClockLine, config, LabscriptError, set_passed_properties, compiler, IntermediateDevice, WaitMonitor, DigitalOut
 from labscript_devices import runviewer_parser, BLACS_tab, BLACS_worker, labscript_device
 
@@ -461,8 +456,6 @@ class CiceroOpalKellyXEM3001Worker(Worker):
     
         # Initialise connection to OPAL KELLY Board
         self.dev = ok.okCFrontPanel()
-        if PY2:
-            self.serial = bytes(self.serial)
         assert self.dev.OpenBySerial(self.serial) == self.dev.NoError
         
         try:
@@ -488,8 +481,6 @@ class CiceroOpalKellyXEM3001Worker(Worker):
             raise RuntimeError('Cannot flash the FPGA for the current reference clock configuration as the .bit file is missing. Please ensure the correct bit file is available at %s'%fpga_path)
             
         self.logger.debug('Flashing FPGA bit file located at: %s'%fpga_path)
-        if PY2:
-            fpga_path = bytes(fpga_path)
         self.dev.ConfigureFPGA(fpga_path)
         assert self.dev.IsFrontPanelEnabled(), 'Flashing of the FPGA failed. The device is not configured with the .bit file correctly'
 

--- a/labscript_devices/DummyIntermediateDevice.py
+++ b/labscript_devices/DummyIntermediateDevice.py
@@ -11,10 +11,6 @@
 #                                                                   #
 #####################################################################
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 # This file represents a dummy labscript device for purposes of testing BLACS
 # and labscript. The device is a Intermediate Device, and can be attached to

--- a/labscript_devices/DummyPseudoclock/__init__.py
+++ b/labscript_devices/DummyPseudoclock/__init__.py
@@ -10,11 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import deprecated_import_alias
 
 

--- a/labscript_devices/DummyPseudoclock/blacs_tabs.py
+++ b/labscript_devices/DummyPseudoclock/blacs_tabs.py
@@ -10,10 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 from blacs.device_base_class import DeviceTab, define_state, MODE_BUFFERED
 
 class DummyPseudoclockTab(DeviceTab):

--- a/labscript_devices/DummyPseudoclock/blacs_workers.py
+++ b/labscript_devices/DummyPseudoclock/blacs_workers.py
@@ -10,10 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 import time
 import labscript_utils.h5_lock
 import h5py

--- a/labscript_devices/DummyPseudoclock/labscript_devices.py
+++ b/labscript_devices/DummyPseudoclock/labscript_devices.py
@@ -10,10 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 # This file represents a dummy labscript device for purposes of testing BLACS
 # and labscript. The device is a PseudoclockDevice, and can be the sole device

--- a/labscript_devices/FlyCapture2Camera/__init__.py
+++ b/labscript_devices/FlyCapture2Camera/__init__.py
@@ -1,4 +1,0 @@
-
-import sys
-if sys.version_info < (3,6):
-    raise RuntimeError("FlyCapture2Camera strongly prefers Python 3.6+")

--- a/labscript_devices/FunctionRunner/__init__.py
+++ b/labscript_devices/FunctionRunner/__init__.py
@@ -10,9 +10,3 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-
-from labscript_utils import check_version
-
-import sys
-if sys.version_info < (3, 5):
-    raise RuntimeError("FunctionRunner requires Python 3.5+")

--- a/labscript_devices/IMAQdxCamera/__init__.py
+++ b/labscript_devices/IMAQdxCamera/__init__.py
@@ -1,9 +1,0 @@
-from labscript_utils import check_version
-
-import sys
-if sys.version_info < (3, 6):
-    raise RuntimeError("IMAQdxCamera driver requires Python 3.6+")
-
-
-check_version('labscript_utils', '2.14.0', '3')
-check_version('labscript', '2.5.2', '3')

--- a/labscript_devices/IMAQdxCamera/blacs_workers.py
+++ b/labscript_devices/IMAQdxCamera/blacs_workers.py
@@ -30,11 +30,6 @@ from labscript_utils.ls_zprocess import Context
 from labscript_utils.shared_drive import path_to_local
 from labscript_utils.properties import set_attributes
 
-# Required for knowing the parent device's hostname when running remotely:
-from labscript_utils import check_version
-
-check_version('zprocess', '2.12.0', '3')
-
 # Don't import nv yet so as not to throw an error, allow worker to run as a dummy
 # device, or for subclasses to import this module to inherit classes without requiring
 # nivision

--- a/labscript_devices/LightCrafterDMD.py
+++ b/labscript_devices/LightCrafterDMD.py
@@ -10,20 +10,13 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 # COMMON IMPORTS
 import base64
 import os
 import struct
 import PIL.Image
-if PY2:
-    from StringIO import StringIO as BytesIO
-else:
-    from io import BytesIO
+from io import BytesIO
     
 import labscript_utils.h5_lock, h5py
 

--- a/labscript_devices/NI_DAQmx/__init__.py
+++ b/labscript_devices/NI_DAQmx/__init__.py
@@ -10,8 +10,3 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode

--- a/labscript_devices/NI_DAQmx/blacs_tabs.py
+++ b/labscript_devices/NI_DAQmx/blacs_tabs.py
@@ -10,15 +10,9 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 import labscript_utils.h5_lock
 import h5py
-from labscript_utils import VersionException, dedent
+from labscript_utils import dedent
 
 from blacs.device_base_class import DeviceTab
 from .utils import split_conn_AO, split_conn_DO
@@ -43,7 +37,7 @@ class NI_DAQmxTab(DeviceTab):
                 to 2.4.0 or less, or recompile the connection table with
                 labscript_devices 2.5.0 or greater.
                 """
-            raise VersionException(dedent(msg))
+            raise RuntimeError(dedent(msg))
 
         num_AO = properties['num_AO']
         num_AI = properties['num_AI']

--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -10,21 +10,9 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 import sys
 import time
 import threading
-import logging
-
-from labscript_utils import check_version
-
-check_version('PyDAQmx', '1.4.2', '2.0.0')
-
 from PyDAQmx import *
 from PyDAQmx.DAQmxConstants import *
 from PyDAQmx.DAQmxTypes import *

--- a/labscript_devices/NI_DAQmx/daqmx_utils.py
+++ b/labscript_devices/NI_DAQmx/daqmx_utils.py
@@ -1,9 +1,3 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
-
-from labscript_utils import check_version
-
-check_version('PyDAQmx', '1.4.2', '2.0.0')
-
 import ctypes
 import PyDAQmx as daqmx
 import PyDAQmx.DAQmxConstants as c

--- a/labscript_devices/NI_DAQmx/labscript_devices.py
+++ b/labscript_devices/NI_DAQmx/labscript_devices.py
@@ -11,16 +11,8 @@
 #                                                                   #
 #####################################################################
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2, check_version
-
-if PY2:
-    str = unicode
-
-
 __version__ = '1.0.0'
 
-check_version('labscript', '2.5.0', '3.0.0')
 
 from labscript import (
     IntermediateDevice,

--- a/labscript_devices/NI_DAQmx/models/NI_PCI_6251.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCI_6251.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCI_6534.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCI_6534.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCI_6713.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCI_6713.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCI_6733.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCI_6733.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCI_DIO_32HS.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCI_DIO_32HS.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCIe_6363.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCIe_6363.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PCIe_6738.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PCIe_6738.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PXI_6733.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PXI_6733.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PXIe_6361.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PXIe_6361.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PXIe_6535.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PXIe_6535.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_PXIe_6738.py
+++ b/labscript_devices/NI_DAQmx/models/NI_PXIe_6738.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_USB_6008.py
+++ b/labscript_devices/NI_DAQmx/models/NI_USB_6008.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_USB_6229.py
+++ b/labscript_devices/NI_DAQmx/models/NI_USB_6229.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/NI_USB_6343.py
+++ b/labscript_devices/NI_DAQmx/models/NI_USB_6343.py
@@ -20,12 +20,6 @@
 #####################################################################
 
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = {

--- a/labscript_devices/NI_DAQmx/models/__init__.py
+++ b/labscript_devices/NI_DAQmx/models/__init__.py
@@ -11,12 +11,6 @@
 #                                                                   #
 #####################################################################
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 import os
 import json
 from labscript_devices import import_class_by_fullname
@@ -34,7 +28,5 @@ __all__ = []
 for model_name in capabilities:
     class_name = 'NI_' + model_name.replace('-', '_')
     path = 'labscript_devices.NI_DAQmx.models.' + class_name + '.' + class_name
-    if PY2 and isinstance(class_name, str):
-        class_name = class_name.encode('utf8')
     globals()[class_name] = import_class_by_fullname(path)
     __all__.append(class_name)

--- a/labscript_devices/NI_DAQmx/models/_subclass_template.py
+++ b/labscript_devices/NI_DAQmx/models/_subclass_template.py
@@ -13,12 +13,6 @@
 
 ${AUTOGENERATION_WARNING}
 
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices.NI_DAQmx.labscript_devices import NI_DAQmx
 
 CAPABILITIES = ${CAPABILITIES}

--- a/labscript_devices/NI_DAQmx/models/generate_subclasses.py
+++ b/labscript_devices/NI_DAQmx/models/generate_subclasses.py
@@ -10,14 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-    import io
-    open = io.open
-
 import os
 import warnings
 import json

--- a/labscript_devices/NI_DAQmx/models/get_capabilities.py
+++ b/labscript_devices/NI_DAQmx/models/get_capabilities.py
@@ -10,19 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-    import io
-
-    open = io.open
-
-
-from labscript_utils import check_version
-
-check_version('PyDAQmx', '1.4.2', '2.0.0')
 
 import numpy as np
 import os

--- a/labscript_devices/NI_DAQmx/register_classes.py
+++ b/labscript_devices/NI_DAQmx/register_classes.py
@@ -10,12 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 import os
 import json
 from labscript_devices import register_classes

--- a/labscript_devices/NI_DAQmx/runviewer_parsers.py
+++ b/labscript_devices/NI_DAQmx/runviewer_parsers.py
@@ -3,7 +3,7 @@ import h5py
 import numpy as np
 
 import labscript_utils.properties as properties
-from labscript_utils import dedent, VersionException
+from labscript_utils import dedent
 
 
 class NI_DAQmxParser(object):
@@ -36,7 +36,7 @@ class NI_DAQmxParser(object):
                     class. The new runviewer parser is not backward compatible with old
                     shot files. Either downgrade labscript_devices to 2.2.0 or less, or
                     recompile the shot with labscript_devices 2.3.0 or greater."""
-                raise VersionException(dedent(msg))
+                raise RuntimeError(dedent(msg))
 
             ports = props['ports']
             static_AO = props['static_AO']

--- a/labscript_devices/NI_DAQmx/utils.py
+++ b/labscript_devices/NI_DAQmx/utils.py
@@ -10,12 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_utils import dedent
 
 

--- a/labscript_devices/NI_PCI_6733.py
+++ b/labscript_devices/NI_PCI_6733.py
@@ -10,12 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices import deprecated_import_alias
 
 # For backwards compatibility with old experiment scripts:

--- a/labscript_devices/NI_PCIe_6363.py
+++ b/labscript_devices/NI_PCIe_6363.py
@@ -10,12 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices import deprecated_import_alias
 
 # For backwards compatibility with old experiment scripts:

--- a/labscript_devices/NI_USB_6343.py
+++ b/labscript_devices/NI_USB_6343.py
@@ -10,12 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
-
 from labscript_devices import deprecated_import_alias
 
 # For backwards compatibility with old experiment scripts:

--- a/labscript_devices/NovaTechDDS9M.py
+++ b/labscript_devices/NovaTechDDS9M.py
@@ -10,10 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 from labscript_devices import runviewer_parser, BLACS_tab
 

--- a/labscript_devices/PhaseMatrixQuickSyn.py
+++ b/labscript_devices/PhaseMatrixQuickSyn.py
@@ -10,10 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 import numpy as np
 from labscript_devices import BLACS_tab, runviewer_parser

--- a/labscript_devices/PineBlaster.py
+++ b/labscript_devices/PineBlaster.py
@@ -10,10 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 from labscript import PseudoclockDevice, Pseudoclock, ClockLine, config, LabscriptError, set_passed_properties
 from labscript_devices import runviewer_parser, BLACS_tab

--- a/labscript_devices/PulseBlaster.py
+++ b/labscript_devices/PulseBlaster.py
@@ -10,10 +10,6 @@
 # file in the root of the project for the full license.             #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 from labscript_devices import BLACS_tab, runviewer_parser
 from labscript_utils import dedent
@@ -857,8 +853,6 @@ class PulseBlasterTab(DeviceTab):
 
 class PulseblasterWorker(Worker):
     def init(self):
-        from labscript_utils import check_version
-        check_version('spinapi', '3.2.0', '4')
         exec('from spinapi import *', globals())
         global h5py; import labscript_utils.h5_lock, h5py
         global zprocess; import zprocess

--- a/labscript_devices/PulseBlasterESRPro200.py
+++ b/labscript_devices/PulseBlasterESRPro200.py
@@ -10,11 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import BLACS_tab, runviewer_parser
 from labscript_devices.PulseBlaster_No_DDS import PulseBlaster_No_DDS, Pulseblaster_No_DDS_Tab, PulseblasterNoDDSWorker, PulseBlaster_No_DDS_Parser
 

--- a/labscript_devices/PulseBlasterESRPro500.py
+++ b/labscript_devices/PulseBlasterESRPro500.py
@@ -10,11 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import  BLACS_tab, runviewer_parser
 from labscript_devices.PulseBlaster_No_DDS import PulseBlaster_No_DDS, Pulseblaster_No_DDS_Tab, PulseblasterNoDDSWorker
 

--- a/labscript_devices/PulseBlasterUSB.py
+++ b/labscript_devices/PulseBlasterUSB.py
@@ -10,11 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import BLACS_tab, runviewer_parser
 from labscript_devices.PulseBlaster_No_DDS import (
     PulseBlaster_No_DDS,

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -10,18 +10,12 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 
 from labscript_devices import BLACS_tab, runviewer_parser
 from labscript_devices.PulseBlaster import PulseBlaster, PulseBlasterParser
 from labscript import PseudoclockDevice, config
 
 import numpy as np
-
-import time
 
 
 class PulseBlaster_No_DDS(PulseBlaster):
@@ -237,8 +231,6 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
 class PulseblasterNoDDSWorker(Worker):
     core_clock_freq = 100
     def init(self):
-        from labscript_utils import check_version
-        check_version('spinapi', '3.2.0', '4')
         exec('from spinapi import *', globals())
         global h5py; import labscript_utils.h5_lock, h5py
         global zprocess; import zprocess

--- a/labscript_devices/PulseBlaster_SP2_24_100_32k.py
+++ b/labscript_devices/PulseBlaster_SP2_24_100_32k.py
@@ -10,11 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript_devices import BLACS_tab, runviewer_parser
 from labscript_devices.PulseBlaster_No_DDS import PulseBlaster_No_DDS, Pulseblaster_No_DDS_Tab, PulseblasterNoDDSWorker
 from labscript_devices.PulseBlaster import PulseBlasterParser

--- a/labscript_devices/PylonCamera/__init__.py
+++ b/labscript_devices/PylonCamera/__init__.py
@@ -1,4 +1,0 @@
-
-import sys
-if sys.version_info < (3,6):
-    raise RuntimeError("PylonCamera strongly prefers Python 3.6+")

--- a/labscript_devices/PythonCamera.py
+++ b/labscript_devices/PythonCamera.py
@@ -10,15 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import print_function, unicode_literals, absolute_import, division
-
-try:
-    from labscript_utils import check_version
-except ImportError:
-    raise ImportError('Require labscript_utils > 2.1.0')
-    
-check_version('labscript', '2.0.1', '3')
-
 from labscript_devices import BLACS_tab
 from labscript_devices.Camera import Camera, CameraTab
 from labscript import set_passed_properties

--- a/labscript_devices/RFBlaster.py
+++ b/labscript_devices/RFBlaster.py
@@ -10,8 +10,6 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-
 import os
 from labscript import PseudoclockDevice, Pseudoclock, ClockLine, IntermediateDevice, DDS, config, startupinfo, LabscriptError, set_passed_properties
 import numpy as np

--- a/labscript_devices/TekScope/blacs_tabs.py
+++ b/labscript_devices/TekScope/blacs_tabs.py
@@ -1,7 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 from blacs.device_base_class import DeviceTab
 
 class TekScopeTab(DeviceTab):

--- a/labscript_devices/TekScope/blacs_workers.py
+++ b/labscript_devices/TekScope/blacs_workers.py
@@ -1,7 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
 import time
 import numpy as np
 from blacs.tab_base_classes import Worker

--- a/labscript_devices/TekScope/labscript_devices.py
+++ b/labscript_devices/TekScope/labscript_devices.py
@@ -1,8 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
 from labscript import Device, LabscriptError, set_passed_properties
 
 class TekScope(Device):

--- a/labscript_devices/ZaberStageController/__init__.py
+++ b/labscript_devices/ZaberStageController/__init__.py
@@ -10,7 +10,3 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-
-import sys
-if sys.version_info < (3, 5):
-    raise RuntimeError("Zaber stage labscript driver requires Python 3.5+")

--- a/labscript_devices/__init__.py
+++ b/labscript_devices/__init__.py
@@ -1,15 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-
-try:
-    from labscript_utils import check_version
-except ImportError:
-    raise ImportError('Require labscript_utils > 2.1.0')
-
-check_version('labscript_utils', '2.13.2', '3')
-from labscript_utils import PY2
-
-if PY2:
-    str = unicode
 
 import os
 import sys
@@ -18,16 +6,10 @@ import imp
 import warnings
 import traceback
 import inspect
-from labscript_utils import labscript_suite_install_dir, dedent
+from labscript_utils import dedent
 from labscript_utils.labconfig import LabConfig
 
 from .__version__ import __version__
-
-check_version('qtutils', '2.0.0', '3.0.0')
-check_version('labscript', '2.6', '3')
-check_version('blacs', '2.7.0', '3.0.0')
-check_version('zprocess', '2.17.0', '3')
-check_version('numpy', '1.15.1', '2')
 
 
 """This file contains the machinery for registering and looking up what BLACS tab and
@@ -77,16 +59,9 @@ def _get_import_paths(import_names):
     If the packages do not exist, ignore them."""
     paths = []
     for name in import_names:
-        if PY2:
-            try:
-                _, location, _ = imp.find_module(name)
-            except ImportError:
-                continue
-            paths.append(os.path.dirname(location))
-        else:
-            spec = importlib.util.find_spec(name)
-            if spec is not None and spec.submodule_search_locations is not None:
-                paths.extend(spec.submodule_search_locations)
+        spec = importlib.util.find_spec(name)
+        if spec is not None and spec.submodule_search_locations is not None:
+            paths.extend(spec.submodule_search_locations)
     return paths
 
 

--- a/labscript_devices/imaqdx_server.py
+++ b/labscript_devices/imaqdx_server.py
@@ -10,24 +10,16 @@
 # the project for the full license.                                 #
 #                                                                   #
 #####################################################################
-from __future__ import division, unicode_literals, print_function, absolute_import
-
 import nivision as nv
 import time
 import numpy as np
-import os
 import sys
-import time
-import zprocess
-from labscript_utils import check_version
 from labscript_utils.camera_server import CameraServer
 import labscript_utils.properties
 import labscript_utils.shared_drive
 # importing this wraps zlock calls around HDF file openings and closings:
 import labscript_utils.h5_lock
 import h5py
-assert sys.version_info >= (3, 6), 'imaqdx_server.py requires Python 3.6 or above.'
-check_version('zprocess', '1.3.3', '3.0')
 import threading
 
 __author__ = ['dt', 'rpanderson', 'cbillington']

--- a/labscript_devices/test_device.py
+++ b/labscript_devices/test_device.py
@@ -1,9 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-from labscript_utils import PY2
-if PY2:
-    str = unicode
-
-import sys
 from labscript_devices import BLACS_tab, runviewer_parser 
 from labscript import Device, LabscriptError, set_passed_properties
 


### PR DESCRIPTION
Remove/update all references to:

`labscript_suite_install_dir` (one reference, was unused)
`PY2`
`__future__`
`labscript_utils.VersionException` -> changed the two uses to a RuntimeError
`sys.version` (all checks were redundant since we don't support PY<3.6)
`labscript_utils.check_version`

Remove any unused imports my linter happened upon whilst cleaning these
out