### PR TITLE
Pb programming

### DIFF
--- a/labscript_devices/PulseBlaster.py
+++ b/labscript_devices/PulseBlaster.py
@@ -1052,8 +1052,7 @@ class PulseblasterWorker(Worker):
                 if fresh or len(self.smart_cache['pulse_program']) != len(pulse_program) or \
                 (self.smart_cache['pulse_program'] != pulse_program).any():
                     self.smart_cache['pulse_program'] = pulse_program
-                    for args in pulse_program:
-                        pb_inst_dds2(*args)
+                    map(pb_inst_dds2, *pulse_program)
             
             if self.programming_scheme == 'pb_start/BRANCH':
                 # We will be triggered by pb_start() if we are are the master pseudoclock or a single hardware trigger

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -381,8 +381,7 @@ class PulseblasterNoDDSWorker(Worker):
                 if fresh or len(self.smart_cache['pulse_program']) != len(pulse_program) or \
                 (self.smart_cache['pulse_program'] != pulse_program).any():
                     self.smart_cache['pulse_program'] = pulse_program
-                    for args in pulse_program:
-                        pb_inst_pbonly(*args)
+                    map(pb_inst_pbonly, *pulse_program)
                         
             if self.programming_scheme == 'pb_start/BRANCH':
                 # We will be triggered by pb_start() if we are are the master pseudoclock or a single hardware trigger


### PR DESCRIPTION
While troubleshooting an intermittent bug with the Pulseblaster an observation was made about extended load times when starting up a new unique shot. When attempting to program rather large instruction sets BLACs would hang upwards of 10-15 seconds. Although using the smart cache feature prevents this from occurring for any repeated shots of the same experiment after the first run, new experimental shots with different instructions results in an extended programming time again. To decrease the loading times the for loop was removed in transition_to_buffered and replaced with the map() function instead. This has shaved off seconds worth of programming time and enabled almost immediate loading of the shot.

I haven't perceived any drawbacks or issues with this so far. Since map() simply returns a list of the results after applying the specified function to each element in the iterable I'm assuming the functionality is essentially the same as the for loop (unless I'm mistaken somewhere). 