### PR TITLE
Fix for PDF docs build

### DIFF
--- a/docs/source/adding_devices.rst
+++ b/docs/source/adding_devices.rst
@@ -37,7 +37,7 @@ There are currently two supported file organization styles for a labscript-devic
 
 The old style has the `labscript_device`, `BLACS_tab`, `BLACS_worker`, and `runviewer_parser` all in the same file, which typically has the same name as the `labscript_device` class name.
 
-The new style allows for arbitrary code organization, but typically has a folder named after the `labscript_device` with each device component in a different file (ie `labscript_devices.py`, `BLACS_workers.py`, etc). With this style, the folder requires an `__init__.py` file (which can be empty) as well as a `register_classes.py` file. This file imports :ref:`<labscript-utils/device_registry>` via
+The new style allows for arbitrary code organization, but typically has a folder named after the `labscript_device` with each device component in a different file (ie `labscript_devices.py`, `BLACS_workers.py`, etc). With this style, the folder requires an `__init__.py` file (which can be empty) as well as a `register_classes.py` file. This file imports :obj:`<labscript-utils:labscript_utils.device_registry>` via
 
 .. code-block:: python
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,6 +172,13 @@ if os.environ.get('READTHEDOCS') and (
 else:
     todo_include_todos = True
 
+# -- Options for PDF output --------------------------------------------------
+
+latex_elements = {
+    # make entire document landscape
+    'geometry': '\\usepackage[landscape]{geometry}',
+}
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/devices/ni_daqs.rst
+++ b/docs/source/devices/ni_daqs.rst
@@ -51,7 +51,12 @@ The current list of pre-subclassed devices is:
 Usage
 ~~~~~
 
-NI Multifunction DAQs generally provide hardware channels for the :ref:`StaticAnalogOut <labscript/StaticAnalogOut>`, :ref:`StaticDigitalOut <labscript/StaticDigitalOut>`, :ref:`AnalogOut <labscript/AnalogOut>`, :ref:`DigitalOut <labscript/DigitalOut>`, and :ref:`AnalogIn <labscript/AnalogIn>` labscript quantities for use in experiments. Exact numbers of channels, performance, and configuration depend on the model of DAQ used.
+NI Multifunction DAQs generally provide hardware channels for 
+:class:`StaticAnalogOut <labscript:labscript.labscript.StaticAnalogOut>`,
+:class:`StaticDigitalOut <labscript:labscript.labscript.StaticDigitalOut>`,
+:class:`AnalogOut <labscript:labscript.labscript.AnalogOut>`,
+:class:`DigitalOut <labscript:labscript.labscript.DigitalOut>`,
+and :class:`AnalogIn <labscript:labscript.labscript.AnalogIn>` labscript quantities for use in experiments. Exact numbers of channels, performance, and configuration depend on the model of DAQ used.
 
 .. code-block:: python
 
@@ -73,7 +78,7 @@ NI Multifunction DAQs generally provide hardware channels for the :ref:`StaticAn
 	AnalogOut('daq_ao0',daq,'ao0')
 	AnalogIn('daq_ai1',daq,'ai1')
 
-NI DAQs are also used within labscript to provide a :ref:`WaitMonitor <labscript/waitmonitor>`. When configured, the `WaitMonitor` allows for arbitrary-length pauses in experiment execution, waiting for some trigger to restart. The monitor provides a measurement of the duration of the wait for use in interpreting the resulting data from the experiment.
+NI DAQs are also used within labscript to provide a :class:`WaitMonitor <labscript:labscript.labscript.waitmonitor>`. When configured, the `WaitMonitor` allows for arbitrary-length pauses in experiment execution, waiting for some trigger to restart. The monitor provides a measurement of the duration of the wait for use in interpreting the resulting data from the experiment.
 
 Configuration uses three digital I/O connections on the DAQ:
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -5,15 +5,15 @@ The **labscript_devices** module contains the low-level hardware interfacing cod
 
 Each "device" is made up of four classes that handle the various tasks.
 
-* `labscript_device` (derives from :doc:`labscript.Device <labscript:api/device>`)
+* `labscript_device` (derives from :obj:`Device <labscript:labscript.labscript.Device>`)
 
    - Defines the interface between the **labscript** API and generates hardware instructions that can be saved to the shot h5 file.
 
-* `BLACS_tab` (derives from :doc:`blacs.device_base_class.DeviceTab <blacs:index>`)
+* `BLACS_tab` (derives from :obj:`DeviceTab <blacs:blacs.device_base_class.DeviceTab>`)
 
    - Defines the graphical tab that is present in the **BLACS** GUI. This tab provides graphical widgets for controlling hardware outputs and visualizing hardware inputs.
 
-* `BLACS_worker` (derives from :doc:`blacs.tab_base_classes.Worker <blacs:index>`)
+* `BLACS_worker` (derives from :class:`Worker <blacs:blacs.tab_base_classes.Worker>`)
 
    - Defines the software control interface to the hardware. The `BLACS_tab` spawns a process that uses this class to send and receive commands with the hardware.
 

--- a/labscript_devices/LightCrafterDMD.py
+++ b/labscript_devices/LightCrafterDMD.py
@@ -61,6 +61,12 @@ class ImageSet(Output):
     height = HEIGHT
     # Set default value to be a black image. Here's a raw BMP!
     default_value = BLANK_BMP
+    """bytes: A black image.
+
+    Raw bitmap data hidden from docs.
+
+    :meta hide-value:
+    """
     
     def __init__(self, name, parent_device, connection = 'Mirror'):
         Output.__init__(self, name, parent_device, connection)


### PR DESCRIPTION
This fixes #81. It also helps the PDF docs with overrun lines by having the pages be landscape, and it fixes a number of broken intersphinx cross-references.