### PR TITLE
Fixed PrawnBlaster runviewer class

### DIFF
--- a/labscript_devices/PrawnBlaster/runviewer_parsers.py
+++ b/labscript_devices/PrawnBlaster/runviewer_parsers.py
@@ -71,7 +71,19 @@ class PrawnBlasterParser(object):
 
         # Generate clocklines and triggers
         clocklines_and_triggers = {}
-        for pulse_program in pulse_programs:
+        
+        for pseudoclock_name, pseudoclock in self.device.child_list.items():
+            # Get pseudoclock index
+            connection_parts = pseudoclock.parent_port.split()
+            # Skip if not one of the 4 possible pseudoclock outputs (there is one for
+            # the wait monitor too potentially)
+            if connection_parts[0] != "pseudoclock":
+                continue
+
+            # Get the pulse program
+            index = int(connection_parts[1])
+            pulse_program = pulse_programs[index]
+
             time = []
             states = []
             trigger_index = 0
@@ -102,15 +114,14 @@ class PrawnBlasterParser(object):
                             states.append(j)
                             t += row["half_period"] * clock_factor
 
-            clock = (np.array(time), np.array(states))
+            pseudoclock_clock = (np.array(time), np.array(states))
 
-            for pseudoclock_name, pseudoclock in self.device.child_list.items():
-                for clock_line_name, clock_line in pseudoclock.child_list.items():
-                    # Ignore the dummy internal wait monitor clockline
-                    if clock_line.parent_port.startswith("GPIO"):
-                        clocklines_and_triggers[clock_line_name] = clock
-                        add_trace(
-                            clock_line_name, clock, self.name, clock_line.parent_port
-                        )
+            for clock_line_name, clock_line in pseudoclock.child_list.items():
+                # Ignore the dummy internal wait monitor clockline
+                if clock_line.parent_port.startswith("GPIO"):
+                    clocklines_and_triggers[clock_line_name] = pseudoclock_clock
+                    add_trace(
+                        clock_line_name, pseudoclock_clock, self.name, clock_line.parent_port
+                    )
 
         return clocklines_and_triggers


### PR DESCRIPTION
There was a bug where runviewer did not correctly parse pulse programs for pseudoclocks/clocklines 1, 2, and 3. There were several bugs (redefinition of a global variable inside a loop and a loop nested when it shouldn't have been.

This should now be resolved. Thanks to Amilson Fritsch for discovering this.