### PR TITLE
Fix bug in FunctionRunner function deserialisation

### DIFF
--- a/labscript_devices/FunctionRunner/utils.py
+++ b/labscript_devices/FunctionRunner/utils.py
@@ -52,6 +52,8 @@ def deserialise_function(
     """Deserialise a function that was serialised by serialise_function. Optional
     __name__ and __file__ arguments set those attributes in the namespace that the
     function will be defined."""
+    if isinstance(name, bytes):
+        name = name.decode('utf8')
     args = deserialise(args)
     kwargs = deserialise(kwargs)
     code = compile(source, '<string>', 'exec', dont_inherit=True,)


### PR DESCRIPTION
In h5py 3.0, all strings from datasets are returned as bytestrings:

https://github.com/h5py/h5py/issues/1338

Luckily this isn't more of an issue throughout the labscript suite,
because we still have lots of code that is unassuming about string
datatypes due to the port from Python 2. But it will probably show up
elsewhere too.