### PR TITLE
Fix bug where FunctionRunner functions were sorted by name

### DIFF
--- a/labscript_devices/FunctionRunner/labscript_devices.py
+++ b/labscript_devices/FunctionRunner/labscript_devices.py
@@ -90,7 +90,7 @@ class FunctionRunner(Device):
     def generate_code(self, hdf5_file):
         # Python's sorting is stable, so items with equal times will remain in the order
         # they were added
-        self.functions.sort()
+        self.functions.sort(key=lambda item: item[0])
         vlenstr = h5py.special_dtype(vlen=str)
         table_dtypes = [
             ('t', float),


### PR DESCRIPTION
Instead of remaining in the order they were added. Functions are
intended to be sorted by time, but not by anything else. But naively
sorting the tuples caused them to be sorted unintentionally by name if
they had the same time.