### PR TITLE
Resolve a bug in runviewer display of Novatech instructions

### DIFF
--- a/labscript_devices/NovaTechDDS9M.py
+++ b/labscript_devices/NovaTechDDS9M.py
@@ -620,8 +620,8 @@ class RunviewerClass(object):
             if 'TABLE_DATA' in hdf5_file['devices/%s' % self.name]:
                 table_data = hdf5_file['devices/%s/TABLE_DATA' % self.name][:]
                 connection_table_properties = labscript_utils.properties.get(hdf5_file, self.name, 'connection_table_properties')
-                update_mode = getattr(connection_table_properties, 'update_mode', 'synchronous')
-                synchronous_first_line_repeat = getattr(connection_table_properties, 'synchronous_first_line_repeat', False)
+                update_mode = connection_table_properties.get('update_mode', 'synchronous')
+                synchronous_first_line_repeat = connection_table_properties.get('synchronous_first_line_repeat', False)
                 if update_mode == 'asynchronous' or synchronous_first_line_repeat:
                     table_data = table_data[1:]
                 for i in range(2):


### PR DESCRIPTION
This is an off-by-one error caused by incorrect use of `getattr` instead
of `dict.get` to provide defaults when reading connection table
properties for the device.