### PR TITLE
Replace QtGui.QSizePolicy → QtWidgets.QSizePolicy

### DIFF
--- a/labscript_devices/IMAQdxCamera/blacs_tabs.py
+++ b/labscript_devices/IMAQdxCamera/blacs_tabs.py
@@ -142,7 +142,7 @@ class IMAQdxCameraTab(DeviceTab):
         layout.addWidget(self.ui)
         self.image = pg.ImageView()
         self.image.setSizePolicy(
-            QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
         )
         self.ui.horizontalLayout.addWidget(self.image)
         self.ui.pushButton_stop.hide()


### PR DESCRIPTION
The former doesn't exist in PyQt5 or PySide2, causing BLACS to fail to load `ImaqdxCamera` tabs.

I do see google results for `QtGui.QSizePolicy`, so it existed at some point - perhaps in Qt4, and maybe provided in `QtGui` since then as an alias for backwards compatibility, but the alias was removed at some point.

I'm confused though because `ImaqdxCamera` is in common use and was written long after we moved away from PyQt4, but I don't see `QtGui.QSizePolicy` in PyQt5 5.9 or 5.15. 5.9 is pretty old, so ... how did this ever work? Was `qtutils` providing an alias? If so I don't see it doing so now.

Whatever, as long as `QtWidgets.QSizePolicy` works for everyone, we should be good.

If anyone wants to check if `QtGui.QSizePolicy` or `QtWidgets.QSizePolicy` exist on their systems before I merge this, would be much appreciated.