### PR TITLE
Replace QtGui.QApplication → QtWidgets.QApplication

### DIFF
--- a/labscript_devices/IMAQdxCamera/blacs_tabs.py
+++ b/labscript_devices/IMAQdxCamera/blacs_tabs.py
@@ -102,7 +102,7 @@ class ImageReceiver(ZMQServer):
         # and not for the Qt event loop as a whole. In any case, this seems to fix it.
         # Manually calling this is usually a sign of bad coding, but I think it is the
         # right solution to this problem. This solves issue #36.
-        QtGui.QApplication.instance().sendPostedEvents()
+        QtWidgets.QApplication.instance().sendPostedEvents()
         return self.NO_RESPONSE
 
 


### PR DESCRIPTION
Similar to #92, it looks like the former was an alias provided by
pyqtgraph for backwards compatibility with code written for PyQt4.
pyqtgraph no longer provides this alias.