### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,15 +75,15 @@ master_doc = 'index'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'qtutils': ('https://qtutils.readthedocs.io/en/stable/', None),
     'pyqtgraph': (
         'https://pyqtgraph.readthedocs.io/en/latest/',
         None,
     ),  # change to stable once v0.11 is published
-    'matplotlib': ('https://matplotlib.org/', None),
-    'h5py': ('http://docs.h5py.org/en/stable/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'h5py': ('https://docs.h5py.org/en/stable/', None),
     'pydaqmx': ('https://pythonhosted.org/PyDAQmx/', None),
     'qt': (
         '',

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
 [options.extras_require]
 docs = 
   PyQt5
-  Sphinx==3.5.3
+  Sphinx==4.4.0
   sphinx-rtd-theme==0.5.2
   recommonmark==0.6.0
   m2r==0.2.1


### PR DESCRIPTION
Docs builds are failing again. Get the error
```
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/home/docs/checkouts/readthedocs.org/user_builds/labscript-devices/envs/96/lib/python3.7/site-packages/jinja2/__init__.py)
```

It appears that updating the sphinx pin to version 4.4.0 avoids this deprecated import.

Also updates some old intersphinx links.