### PR TITLE
Camera error control

### DIFF
--- a/labscript_devices/AndorSolis/blacs_workers.py
+++ b/labscript_devices/AndorSolis/blacs_workers.py
@@ -20,6 +20,7 @@ class AndorCamera(object):
         from .andor_sdk.andor_utils import AndorCam
         self.camera = AndorCam()
         self.attributes = self.camera.default_acquisition_attrs
+        self.exception_on_failed_shot = True
 
     def set_attributes(self, attr_dict):
         self.attributes.update(attr_dict)

--- a/labscript_devices/FlyCapture2Camera/blacs_workers.py
+++ b/labscript_devices/FlyCapture2Camera/blacs_workers.py
@@ -91,7 +91,8 @@ class FlyCapture2_Camera(object):
         self.pixel_formats = IntEnum('pixel_formats',fmts)
 
         self._abort_acquisition = False
-        
+        self.exception_on_failed_shot = True
+
         # check if GigE camera. If so, ensure max packet size is used
         cam_info = self.camera.getCameraInfo()
         if cam_info.interfaceType == PyCapture2.INTERFACE_TYPE.GIGE:

--- a/labscript_devices/IMAQdxCamera/blacs_workers.py
+++ b/labscript_devices/IMAQdxCamera/blacs_workers.py
@@ -67,6 +67,7 @@ class MockCamera(object):
     def __init__(self):
         print("Starting device worker as a mock device")
         self.attributes = {}
+        self.exception_on_failed_shot = True
 
     def set_attributes(self, attributes):
         self.attributes.update(attributes)

--- a/labscript_devices/IMAQdxCamera/blacs_workers.py
+++ b/labscript_devices/IMAQdxCamera/blacs_workers.py
@@ -118,7 +118,7 @@ class MockCamera(object):
 
 
 class IMAQdx_Camera(object):
-    def __init__(self, serial_number, exception_on_failed_shot=True):
+    def __init__(self, serial_number):
         global nv
         import nivision as nv
         _monkeypatch_imaqdispose()
@@ -139,7 +139,7 @@ class IMAQdx_Camera(object):
         )
         # Keep an img attribute so we don't have to create it every time
         self.img = nv.imaqCreateImage(nv.IMAQ_IMAGE_U16)
-        self.exception_on_failed_shot = exception_on_failed_shot
+        self.exception_on_failed_shot = True
         self._abort_acquisition = False
 
     def set_attributes(self, attr_dict):
@@ -287,8 +287,7 @@ class IMAQdxCameraWorker(Worker):
         if self.mock:
             return MockCamera()
         else:
-            return self.interface_class(self.serial_number, 
-                                        exception_on_failed_shot=self.exception_on_failed_shot)
+            return self.interface_class(self.serial_number)
 
     def set_attributes_smart(self, attributes):
         """Call self.camera.set_attributes() to set the given attributes, only setting
@@ -396,6 +395,7 @@ class IMAQdxCameraWorker(Worker):
             self.stop_acquisition_timeout = properties['stop_acquisition_timeout']
             self.exception_on_failed_shot = properties['exception_on_failed_shot']
             saved_attr_level = properties['saved_attribute_visibility_level']
+            self.camera.exception_on_failed_shot = self.exception_on_failed_shot
         # Only reprogram attributes that differ from those last programmed in, or all of
         # them if a fresh reprogramming was requested:
         if fresh:

--- a/labscript_devices/IMAQdxCamera/blacs_workers.py
+++ b/labscript_devices/IMAQdxCamera/blacs_workers.py
@@ -224,7 +224,9 @@ class IMAQdx_Camera(object):
                     if self.exception_on_failed_shot:
                         raise
                     else:
+                        # stop acquisition
                         print(e, file=sys.stderr)
+                        break
                     
                     
                     

--- a/labscript_devices/IMAQdxCamera/blacs_workers.py
+++ b/labscript_devices/IMAQdxCamera/blacs_workers.py
@@ -174,7 +174,7 @@ class IMAQdx_Camera(object):
             if not a.Readable:
                 continue
             attributes.append(a.Name.decode('utf8'))
-        return sorted(attributes)
+        return attributes
 
     def get_attribute(self, name):
         """Return current value of attribute of the given name"""

--- a/labscript_devices/IMAQdxCamera/labscript_devices.py
+++ b/labscript_devices/IMAQdxCamera/labscript_devices.py
@@ -29,12 +29,12 @@ class IMAQdxCamera(TriggerableDevice):
                 "pixel_size",
                 "magnification",
                 "manual_mode_camera_attributes",
+                "exception_on_failed_shot",
                 "mock",
             ],
             "device_properties": [
                 "camera_attributes",
                 "stop_acquisition_timeout",
-                "exception_on_failed_shot",
                 "saved_attribute_visibility_level"
             ],
         }
@@ -162,6 +162,7 @@ class IMAQdxCamera(TriggerableDevice):
         if isinstance(serial_number, (str, bytes)):
             serial_number = int(serial_number, 16)
         self.serial_number = serial_number
+        self.exception_on_failed_shot = exception_on_failed_shot
         self.BLACS_connection = hex(self.serial_number)[2:].upper()
         if camera_attributes is None:
             camera_attributes = {}

--- a/labscript_devices/IMAQdxCamera/labscript_devices.py
+++ b/labscript_devices/IMAQdxCamera/labscript_devices.py
@@ -29,12 +29,12 @@ class IMAQdxCamera(TriggerableDevice):
                 "pixel_size",
                 "magnification",
                 "manual_mode_camera_attributes",
-                "exception_on_failed_shot",
                 "mock",
             ],
             "device_properties": [
                 "camera_attributes",
                 "stop_acquisition_timeout",
+                "exception_on_failed_shot",
                 "saved_attribute_visibility_level"
             ],
         }
@@ -162,7 +162,6 @@ class IMAQdxCamera(TriggerableDevice):
         if isinstance(serial_number, (str, bytes)):
             serial_number = int(serial_number, 16)
         self.serial_number = serial_number
-        self.exception_on_failed_shot = exception_on_failed_shot
         self.BLACS_connection = hex(self.serial_number)[2:].upper()
         if camera_attributes is None:
             camera_attributes = {}

--- a/labscript_devices/PylonCamera/blacs_workers.py
+++ b/labscript_devices/PylonCamera/blacs_workers.py
@@ -45,6 +45,8 @@ class Pylon_Camera(object):
         # Keep a nodeMap reference so we don't have to re-create a lot
         self.nodeMap = self.camera.GetNodeMap()
         self._abort_acquisition = False
+        self.exception_on_failed_shot = True
+
 
     def set_attributes(self, attributes_dict):
         """Sets all attribues in attr_dict.

--- a/labscript_devices/SpinnakerCamera/blacs_workers.py
+++ b/labscript_devices/SpinnakerCamera/blacs_workers.py
@@ -55,6 +55,7 @@ class Spinnaker_Camera(object):
 
         # Set the abort acquisition thingy:
         self._abort_acquisition = False
+        self.exception_on_failed_shot = True
 
     def get_attribute_names(self, visibility):
         names = []


### PR DESCRIPTION
In the IMAQdx camera class the option exception_on_failed_shot did not catch all the missing shot errors in the lab.  The reason is that for some reason about 0.1% of the time with our gige cameras we would get an error "nivision.core.ImaqDxError: 3220606990: No acquisition in progress."  I don't know why the acquisition would stop before taking all of the images, but sometimes it does.  When this error occurs it pops up a big error box, which can be undesirable.

As a result I added exception_on_failed_shot into the IMAQdx_Camera class so it too can catch errors and respond just as IMAQdxCameraWorker already does.

In addition I added this attribute to all of the cameras that subclass IMAQdx_Camera BUT it does not do anything.  This is so that IMAQdxCameraWorker's subclasses can still write the attribute without creating an error condition.

Also removed sorting of camera attributes because the actually need to be set in a specific order and sorting breaks this.
