### PR TITLE
Allow arbitrary terminal connections for NI DAQmx devices

### DIFF
--- a/labscript_devices/NI_DAQmx/blacs_tabs.py
+++ b/labscript_devices/NI_DAQmx/blacs_tabs.py
@@ -66,6 +66,7 @@ class NI_DAQmxTab(DeviceTab):
 
         clock_terminal = properties['clock_terminal']
         clock_mirror_terminal = properties['clock_mirror_terminal']
+        connected_terminals = properties['connected_terminals']
         static_AO = properties['static_AO']
         static_DO = properties['static_DO']
         clock_limit = properties['clock_limit']

--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -178,11 +178,7 @@ class NI_DAQmxOutputWorker(Worker):
                 )
         else:
             for terminal_pair in self.connected_terminals:
-                DAQmxDisconnectTerms(
-                    terminal_pair[0],
-                    terminal_pair[1],
-                    DAQmx_Val_DoNotInvertPolarity,
-                )
+                DAQmxDisconnectTerms(terminal_pair[0], terminal_pair[1])
 
     def program_buffered_DO(self, DO_table):
         """Create the DO task and program in the DO table for a shot. Return a

--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -172,15 +172,15 @@ class NI_DAQmxOutputWorker(Worker):
         if connected:
             for terminal_pair in self.connected_terminals:
                 DAQmxConnectTerms(
-                    self.terminal_pair[0],
-                    self.terminal_pair[1],
+                    terminal_pair[0],
+                    terminal_pair[1],
                     DAQmx_Val_DoNotInvertPolarity,
                 )
         else:
             for terminal_pair in self.connected_terminals:
                 DAQmxDisconnectTerms(
-                    self.terminal_pair[0],
-                    self.terminal_pair[1],
+                    terminal_pair[0],
+                    terminal_pair[1],
                     DAQmx_Val_DoNotInvertPolarity,
                 )
 

--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -163,6 +163,27 @@ class NI_DAQmxOutputWorker(Worker):
         else:
             DAQmxDisconnectTerms(self.clock_terminal, self.clock_mirror_terminal)
 
+    def set_connected_terminals_connected(self, connected):
+        """Connect the terminals in the connected terminals list.
+        Allows on daisy chaining of the clock line to/from other devices
+        that do not have a direct route (see Device Routes in NI MAX)."""
+        if self.connected_terminals is None:
+            return
+        if connected:
+            for terminal_pair in self.connected_terminals:
+                DAQmxConnectTerms(
+                    self.terminal_pair[0],
+                    self.terminal_pair[1],
+                    DAQmx_Val_DoNotInvertPolarity,
+                )
+        else:
+            for terminal_pair in self.connected_terminals:
+                DAQmxDisconnectTerms(
+                    self.terminal_pair[0],
+                    self.terminal_pair[1],
+                    DAQmx_Val_DoNotInvertPolarity,
+                )
+
     def program_buffered_DO(self, DO_table):
         """Create the DO task and program in the DO table for a shot. Return a
         dictionary of the final values of each channel in use"""
@@ -320,6 +341,9 @@ class NI_DAQmxOutputWorker(Worker):
         # Mirror the clock terminal, if applicable:
         self.set_mirror_clock_terminal_connected(True)
 
+        # Mirror other terminals, if applicable
+        self.set_connected_terminals_connected(True)
+
         # Program the output tasks and retrieve the final values of each output:
         DO_final_values = self.program_buffered_DO(DO_table)
         AO_final_values = self.program_buffered_AO(AO_table)
@@ -371,6 +395,9 @@ class NI_DAQmxOutputWorker(Worker):
 
         # Remove the mirroring of the clock terminal, if applicable:
         self.set_mirror_clock_terminal_connected(False)
+
+        # Remove connections between other terminals, if applicable:
+        self.set_connected_terminals_connected(False)
 
         # Set up manual mode tasks again:
         self.start_manual_mode_tasks()

--- a/labscript_devices/NI_DAQmx/labscript_devices.py
+++ b/labscript_devices/NI_DAQmx/labscript_devices.py
@@ -58,6 +58,7 @@ class NI_DAQmx(IntermediateDevice):
                 "static_AO",
                 "static_DO",
                 "clock_mirror_terminal",
+                "connected_terminals",
                 "AI_range",
                 "AI_start_delay",
                 "AI_start_delay_ticks",
@@ -93,6 +94,7 @@ class NI_DAQmx(IntermediateDevice):
         static_AO=None,
         static_DO=None,
         clock_mirror_terminal=None,
+        connected_terminals=None,
         acquisition_rate=None,
         AI_range=None,
         AI_range_Diff=None,
@@ -132,6 +134,9 @@ class NI_DAQmx(IntermediateDevice):
             clock_mirror_terminal (str, optional): Channel string of digital output
                 that mirrors the input clock. Useful for daisy-chaning DAQs on the same
                 clockline.
+            connected_terminals (list, optional): List of pairs of strings of digital inputs
+                and digital outputs that will be connected. Useful for daisy-chaining DAQs
+                on the same clockline when they do not have direct routes (see Device Routes in NI MAX).
             acquisiton_rate (float, optional): Default sample rate of inputs.
             AI_range (iterable, optional): A `[Vmin, Vmax]` pair that sets the analog
                 input voltage range for all analog inputs.


### PR DESCRIPTION
This pull request adds the ability to connect any (hardware supported) pair of terminals in NI DAQmx devices, generalizing the mirror clock terminal feature.

This is useful for sharing clocks between devices that lack the ability to get all of their clocks from the same trigger line, which I observed in a setup that mixed PXI-6733 and PXIe-6535 NI cards. Although not particularly useful for setups configured with a clockline per NI card, this may be helpful for transitioning setups designed around a single clockline.

I have verified that this works as expected to connect one PXI trigger to another. In particular, our setup (for now) has a trigger mirrored from the input of the PXI-6733 connected to another trigger, and uses that as the clock for the PXIe-6535.