### PR TITLE
Get shot globals dependency break

### DIFF
--- a/labscript_devices/FunctionRunner/blacs_workers.py
+++ b/labscript_devices/FunctionRunner/blacs_workers.py
@@ -14,9 +14,9 @@ import os
 from time import monotonic
 import numpy as np
 import labscript_utils.h5_lock
+from labscript_utils.shot_utils import get_shot_globals
 import h5py
 from blacs.tab_base_classes import Worker
-import runmanager
 import runmanager.remote
 from zprocess import rich_print
 from .utils import deserialise_function
@@ -48,7 +48,7 @@ class ShotContext(object):
     def __init__(self, h5_file, device_name):
         self.h5_file = h5_file
         self.device_name = device_name
-        self.globals = runmanager.get_shot_globals(h5_file)
+        self.globals = get_shot_globals(h5_file)
 
 
 class FunctionRunnerWorker(Worker):

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -23,5 +23,4 @@ python:
         path: .
         extra_requirements:
             - docs
-   system_packages: true
    

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
   runmanager>=3.0.0
   importlib_metadata
   labscript>=3.0.0
-  labscript_utils>=3.0.0
+  labscript_utils>=3.3.0
   numpy>=1.15.1
   pillow
   tqdm


### PR DESCRIPTION
Updates `runmanager.get_shot_globals` to use `labscript_utils.shot_utils.get_shot_globals`

Partially addresses labscript-suite/runmanager#98