### PR TITLE
PrawnBlaster binary programming

### DIFF
--- a/labscript_devices/PrawnBlaster/blacs_workers.py
+++ b/labscript_devices/PrawnBlaster/blacs_workers.py
@@ -340,6 +340,10 @@ class PrawnBlasterWorker(Worker):
             if (fresh or self.smart_cache[pseudoclock] is None) and self.fast_serial:
                 print('binary programming')
                 self.prawnblaster.write(b"setb %d %d %d\r\n" % (pseudoclock, 0, len(pulse_program)))
+                response = self.prawnblaster.readline().decode()
+                assert (
+                    response == "ready\r\n"
+                ), f"PrawnBlaster said '{response}', expected 'ready'"
                 program_array = np.array([pulse_program['half_period'],
                                           pulse_program['reps']], dtype='<u4').T
                 self.prawnblaster.write(program_array.tobytes())

--- a/labscript_devices/PrawnBlaster/blacs_workers.py
+++ b/labscript_devices/PrawnBlaster/blacs_workers.py
@@ -72,7 +72,8 @@ class PrawnBlasterWorker(Worker):
             assert self.prawnblaster.readline().decode() == "ok\r\n"
 
         # Check if fast serial is available
-        self.fast_serial = self.version_greater_than((1, 1, 0))
+        version, _ = self.get_version()
+        self.fast_serial = version >= (1, 1, 0)
 
     def get_version(self):
         self.prawnblaster.write(b"version\r\n")
@@ -86,24 +87,10 @@ class PrawnBlasterWorker(Worker):
             if version_overclock_list[1] == 'overclock':
                 overclock = True
 
-        version_number = version_overclock_list[0].split('.')
-        assert len(version_number) == 3
+        version = tuple(int(v) for v in version_overclock_list[0].split('.'))
+        assert len(version) == 3
 
-        return (int(version_number[0]), int(version_number[1]), int(version_number[2]), overclock)
-
-    def version_greater_than(self, target_version):
-        version = self.get_version()
-        if version[0] > target_version[0]:
-            return True
-        if version[0] < target_version[0]:
-            return False
-        if version[1] > target_version[1]:
-            return True
-        if version[1] < target_version[1]:
-            return False
-        if version[2] >= target_version[2]:
-            return True
-        return False
+        return version, overclock
 
     def check_status(self):
         """Checks the operational status of the PrawnBlaster.

--- a/labscript_devices/PrawnBlaster/blacs_workers.py
+++ b/labscript_devices/PrawnBlaster/blacs_workers.py
@@ -353,11 +353,9 @@ class PrawnBlasterWorker(Worker):
             if (fresh or self.smart_cache[pseudoclock] is None) and self.fast_serial:
                 print('binary programming')
                 self.prawnblaster.write(b"setb %d %d %d\r\n" % (pseudoclock, 0, len(pulse_program)))
-                serial_buffer = b''
-                for i in range(0, len(pulse_program)):
-                    serial_buffer += struct.pack('<I', pulse_program[i]['half_period'])
-                    serial_buffer += struct.pack('<I', pulse_program[i]['reps'])
-                self.prawnblaster.write(serial_buffer)
+                program_array = np.array([pulse_program['half_period'],
+                                          pulse_program['reps']], dtype='<u4').T
+                self.prawnblaster.write(program_array.tobytes())
                 response = self.prawnblaster.readline().decode()
                 assert (
                     response == "ok\r\n"

--- a/labscript_devices/PrawnBlaster/blacs_workers.py
+++ b/labscript_devices/PrawnBlaster/blacs_workers.py
@@ -13,6 +13,7 @@
 import time
 import labscript_utils.h5_lock
 import h5py
+import numpy as np
 from blacs.tab_base_classes import Worker
 from labscript_utils.connections import _ensure_str
 import labscript_utils.properties as properties
@@ -38,6 +39,7 @@ class PrawnBlasterWorker(Worker):
         global time; import time
         global re; import re
         global numpy; import numpy
+        global struct; import struct
         global zprocess; import zprocess
         self.smart_cache = {}
         self.cached_pll_params = {}
@@ -292,6 +294,7 @@ class PrawnBlasterWorker(Worker):
 
         # Program instructions
         for pseudoclock, pulse_program in enumerate(pulse_programs):
+            total_inst = len(pulse_program)
             # check if it is more efficient to fully refresh
             if not fresh and self.smart_cache[pseudoclock] is not None:
                 # get more convenient handles to smart cache arrays
@@ -308,7 +311,7 @@ class PrawnBlasterWorker(Worker):
                     val_diffs = np.sum(curr_inst != pulse_program[:n_curr])
                     new_inst = val_diffs + n_diff
                 else:
-                    new_inst = np.sum(curr_inst != inst)
+                    new_inst = np.sum(curr_inst != pulse_program)
 
                 if new_inst / total_inst > 0.1:
                     fresh = True


### PR DESCRIPTION
The labscript-devices side of [PrawnBlaster PR #25](https://github.com/labscript-suite/PrawnBlaster/pull/25).

Adds a fast binary mode for reprogramming the entire sequence, as well as heuristics for deciding when to use binary mode instead of incremental programming.

Verification testing has been performed, but performance testing is incomplete.