### PR TITLE
Changed SpinnakerCamera StreamBufferCountMode

### DIFF
--- a/labscript_devices/SpinnakerCamera/blacs_workers.py
+++ b/labscript_devices/SpinnakerCamera/blacs_workers.py
@@ -198,14 +198,15 @@ class Spinnaker_Camera(object):
             self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
             self.set_attribute('AcquisitionMode', 'Continuous')
         elif bufferCount == 1:
+            # The StreamBufferCountMode originally was set to 'Auto', but this feature was depreciated by Spinnaker version 3.0.0.118
             self.set_stream_attribute('StreamBufferCountMode', 'Manual')
-            self.set_stream_attribute('StreamBufferCountManual', 3)
-            self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
+            self.set_stream_attribute('StreamBufferCountManual', 1)
+            self.set_stream_attribute('StreamBufferHandlingMode', 'OldestFirst')
             self.set_attribute('AcquisitionMode', 'SingleFrame')
         else:
             self.set_stream_attribute('StreamBufferCountMode', 'Manual')
             self.set_stream_attribute('StreamBufferCountManual', bufferCount)
-            self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
+            self.set_stream_attribute('StreamBufferHandlingMode', 'OldestFirst')
             self.set_attribute('AcquisitionMode', 'MultiFrame')
             self.set_attribute('AcquisitionFrameCount', bufferCount)
 

--- a/labscript_devices/SpinnakerCamera/blacs_workers.py
+++ b/labscript_devices/SpinnakerCamera/blacs_workers.py
@@ -198,12 +198,14 @@ class Spinnaker_Camera(object):
             self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
             self.set_attribute('AcquisitionMode', 'Continuous')
         elif bufferCount == 1:
-            self.set_stream_attribute('StreamBufferCountMode', 'Auto')
-            self.set_stream_attribute('StreamBufferHandlingMode', 'OldestFirst')
+            self.set_stream_attribute('StreamBufferCountMode', 'Manual')
+            self.set_stream_attribute('StreamBufferCountManual', 3)
+            self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
             self.set_attribute('AcquisitionMode', 'SingleFrame')
         else:
-            self.set_stream_attribute('StreamBufferCountMode', 'Auto')
-            self.set_stream_attribute('StreamBufferHandlingMode', 'OldestFirst')
+            self.set_stream_attribute('StreamBufferCountMode', 'Manual')
+            self.set_stream_attribute('StreamBufferCountManual', bufferCount)
+            self.set_stream_attribute('StreamBufferHandlingMode', 'NewestFirst')
             self.set_attribute('AcquisitionMode', 'MultiFrame')
             self.set_attribute('AcquisitionFrameCount', bufferCount)
 


### PR DESCRIPTION
Previously, the buffer count mode for the Spinnaker Camera in blacs_workers.py was set to Auto. This Auto feature has been depreciated by FLIR so I changed it to be manual in the same format as the continuous mode. In the case where bufferCount == 1, I set it to 3 because the Spinnaker SDK mentioned that 3 was the minimum buffer count.