### PR TITLE
TekScope bug fix

### DIFF
--- a/labscript_devices/TekScope/blacs_workers.py
+++ b/labscript_devices/TekScope/blacs_workers.py
@@ -27,7 +27,8 @@ class TekScopeWorker(Worker):
             self.scope_params = labscript_utils.properties.get(
                 hdf5_file, device_name, 'device_properties'
             )
-            self.scope.dev.timeout = 1000 * self.scope_params.get('timeout', 5)
+
+        self.scope.dev.timeout = 1000 * self.scope_params.get('timeout', 5)
 
         self.scope.unlock()
         self.scope.set_acquire_state(True)
@@ -61,10 +62,11 @@ class TekScopeWorker(Worker):
 
         # Open the file after download so as not to hog the file lock
         with h5py.File(self.h5file, 'r+') as hdf_file:
-            grp = hdf_file.create_group('/data/traces')
+            grp = hdf_file.require_group('/data/traces')
             print('Saving traces...')
             dset = grp.create_dataset(self.device_name, data=data)
             dset.attrs.update(wfmp[ch])
+        
         print('Done!')
         return True
 


### PR DESCRIPTION
The TekScope device had a bug where it was calling `hdf_file.create_group('/data/traces')` in transition to manual.  This is a problem because if you have two scopes this code fails the second time.  Instead (and like the camera devices) I changed this to `grp = hdf_file.require_group('/data/traces')`.  Trivial.

Also in transition to buffered the code `self.scope.dev.timeout = 1000 * self.scope_params.get('timeout', 5)` appeared while the h5 file was open (which was not needed).  Moved this after closing the h5 file to slightly reduce the time that the file was locked.