### PR TITLE
Mark PineBlaster as deprecated in documentation

### DIFF
--- a/docs/source/devices/pineblaster.rst
+++ b/docs/source/devices/pineblaster.rst
@@ -3,6 +3,9 @@ Pineblaster
 
 This labscript device controls the `PineBlaster <https://labscriptsuite.org/hardware/pineblaster/>`_ open-source digital pattern generator based on the Digilent chipKIT Max32 Prototyping platform.
 
+.. warning::
+    The chipKIT Max32 board is no longer commercially available. As such, this device is considered deprecated. We recommend the :doc:`PrawnBlaster <prawnblaster>` as a replacement device (for both new users looking for a cheap pseudoclock, and existing users of the PineBlaster). The PrawnBlaster microcontroller only costs ~$5USD and supports more instructions, multiple independent pseudoclocks, an internal wait monitor, and an easier connection for referencing to an external clock source.
+
 Detailed Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Updates the PineBlaster documentation with a warning indicating the board is no longer available to buy, that we consider the device deprecated, and indicating the PrawnBlaster should be used instead